### PR TITLE
Use build dir as default for Pre stage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,7 @@ require 'rubycritic/rake_task'
 require 'rdoc/task'
 require 'inch/rake'
 require 'rake/testtask'
+require_relative 'lib/utils/setup.rb'
 
 task default: %w[toolchain:test toolchain:lint]
 
@@ -11,6 +12,8 @@ def toolchain_path
 end
 
 namespace :docs do
+  @setup_done = false
+
   desc 'Run through all stages'
   task :all do
     %w[clean test pre build post notify].each { |t| Rake::Task["docs:#{t}"].execute }
@@ -29,12 +32,15 @@ namespace :docs do
 
   desc 'Run pre-processing stage'
   task :pre do
+    Toolchain::Setup.setup()
+    @setup_done = true
     debug = '--debug' if ENV.key?('DEBUG')
     ruby "#{toolchain_path}/bin/pre.rb #{debug}"
   end
 
   desc 'Run build stage'
   task :build do
+    Toolchain::Setup.setup() unless @setup_done
     debug = '--debug' if ENV.key?('DEBUG')
     ruby "#{toolchain_path}/bin/build.rb #{debug}"
   end

--- a/bin/build.rb
+++ b/bin/build.rb
@@ -12,8 +12,6 @@ def main(argv = ARGV)
   end
 
   stage_log(:build, 'Starting build stage')
-  stage_log(:build, "running build setup on content folder: #{args.content}")
-  Toolchain::Build.setup(content: args.content)
   stage_log(:build, "running build with index: #{args.index}")
   Toolchain::Build.build(index: args.index)
   stage_log(:build, 'Build done')

--- a/bin/test.rb
+++ b/bin/test.rb
@@ -37,7 +37,9 @@ def main(argv = ARGV)
   log('ARGS', args)
   log('INDEX', index_adoc)
 
-  adoc = Toolchain::Adoc.load_doc(index_adoc)
+  adoc = Toolchain::Adoc.load_doc(index_adoc,
+    'root' => ::Toolchain.content_path
+  )
   original = adoc.original
   parsed = adoc.parsed
   attributes = adoc.attributes

--- a/bin/test.rb
+++ b/bin/test.rb
@@ -38,7 +38,7 @@ def main(argv = ARGV)
   log('INDEX', index_adoc)
 
   adoc = Toolchain::Adoc.load_doc(index_adoc,
-    'root' => ::Toolchain.content_path
+    'root' => ::Toolchain.document_root
   )
   original = adoc.original
   parsed = adoc.parsed

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,6 +1,6 @@
 asciidoc:
   index:
-    file: content/index.adoc
+    file: index.adoc
   multipage_level: 2
 
 build:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,5 +25,5 @@ notify:
       file: /tmp/slack.json
 
 toc:
-  json_file: /tmp/toc.json
-  html_file: /tmp/toc.html
+  json_file: toc.json
+  html_file: toc.html

--- a/lib/post.d/html_postprocessing.rb
+++ b/lib/post.d/html_postprocessing.rb
@@ -21,11 +21,11 @@ module Toolchain
       def initialize(priority = 0)
         super(priority)
         @html_dir = CM.get('build.html_dir')
-        @toc_html_file = CM.get('toc.html_file')
-        @html_files_array = Dir.glob('*.html', base: Toolchain.html_path).delete_if do |file|
-          File.basename(file).start_with?('docinfo')
-        end.map do |file|
-          File.join(@html_dir, file)
+        @toc_html_file = File.join(
+          ::Toolchain.build_path,
+          CM.get('toc.html_file'))
+        @html_files_array = Dir.glob('*.html', base: ::Toolchain.html_path).map do |file|
+          File.join(::Toolchain.html_path, file)
         end
       end
 
@@ -52,7 +52,7 @@ module Toolchain
         file_content = File.read(html_file)
         document = Nokogiri::HTML(file_content)
         document.css('div#toc').remove
-        document.css('div#header').children.first.add_previous_sibling(html_fragment)      
+        document.css('div#header').children.first.add_previous_sibling(html_fragment)
         modified_html = document.to_html
         return html_file if File.write(html_file, modified_html)
       end

--- a/lib/pre.d/combine_transpile_js.rb
+++ b/lib/pre.d/combine_transpile_js.rb
@@ -27,7 +27,7 @@ module Toolchain
       # Returns the results of the substitution.
       def run(filepaths = nil)
         # TODO: add files from header.js.d to docinfo.html and footer.js.d to docinfo-footer.html
-        root = ::Toolchain.document_root
+        root = ::Toolchain.build_path
         header_path = filepaths.nil? ? File.join(root, @header_name_default) : filepaths.header
         footer_path = filepaths.nil? ? File.join(root, @footer_name_default) : filepaths.footer
         # js_header_files = Dir[content_path + '/js/header.js.d/*.js']

--- a/lib/pre.d/create_toc.rb
+++ b/lib/pre.d/create_toc.rb
@@ -15,12 +15,16 @@ module Toolchain
     ##
     # Adds modules for preprocessing files.
     class CreateTOC < BaseProcess
-      @@multipage_level = CM.get('asciidoc.multipage_level')
-      @@default_json_filepath = CM.get('toc.json_file')
-      @@default_html_filepath = CM.get('toc.html_file')
 
       def initialize(priority = 0)
         super(priority)
+        @multipage_level = CM.get('asciidoc.multipage_level')
+        @default_json_filepath = File.join(
+          ::Toolchain.build_path,
+          CM.get('toc.json_file'))
+        @default_html_filepath = File.join(
+          ::Toolchain.build_path,
+          CM.get('toc.html_file'))
       end
 
       ##
@@ -33,16 +37,14 @@ module Toolchain
       #
       def run(
         adoc = nil, # Toolchain::Adoc.load_doc(CM.get('asciidoc.index.file')),
-        json_filepath = @@default_json_filepath,
-        html_filepath = @@default_html_filepath
+        json_filepath = @default_json_filepath,
+        html_filepath = @default_html_filepath
       )
         # TODO: document this bit since it's quite confusing
         stage_log(:pre, '[Create TOC] Starting')
-        if adoc.nil?
-          adoc = Toolchain::Adoc.load_doc(
-            CM.get('asciidoc.index.file')
-          )
-        end
+        adoc = Toolchain::Adoc.load_doc(
+          File.basename(CM.get('asciidoc.index.file'))
+        ) if adoc.nil?
         parsed = adoc.parsed
         attributes = adoc.attributes
         lines = parsed.reader.source_lines
@@ -80,13 +82,13 @@ module Toolchain
             children: []
           )
           while level <= stack.last.level
-            stack.pop 
+            stack.pop
             ancestors.pop
           end
 
           current.parent = stack.last
           ancestors << current.parent.id
-          founder = ancestors[@@multipage_level] || current.id
+          founder = ancestors[@multipage_level] || current.id
 
           # add current element to it's parent's children list
           current.parent.children << current
@@ -114,7 +116,7 @@ module Toolchain
         toc_html_dom.at_css('#toc') << generate_html_from_toc(toc_openstruct.children)
 
         # convert Nokogiri HTML Object to string
-        toc_html_string = toc_html_dom.to_xhtml(indent: 3) 
+        toc_html_string = toc_html_dom.to_xhtml(indent: 3)
         File.open(html_filepath, 'w+') do |html_file|
           html_file.write(toc_html_string)
         end
@@ -146,7 +148,7 @@ module Toolchain
       # Useful for converting OpenStruct Hash for later conversion to JSON
       #
       def openstruct_to_hash(object, hash = {})
-      return object unless object.is_a? OpenStruct
+        return object unless object.is_a? OpenStruct
         object.each_pair do |key, value|
           hash[key] = case value
                       when OpenStruct then openstruct_to_hash(value)

--- a/lib/pre.d/create_toc.rb
+++ b/lib/pre.d/create_toc.rb
@@ -42,9 +42,11 @@ module Toolchain
       )
         # TODO: document this bit since it's quite confusing
         stage_log(:pre, '[Create TOC] Starting')
-        adoc = Toolchain::Adoc.load_doc(
-          File.basename(CM.get('asciidoc.index.file'))
-        ) if adoc.nil?
+        if adoc.nil?
+          adoc = Toolchain::Adoc.load_doc(
+            File.basename(CM.get('asciidoc.index.file'))
+          )
+        end
         parsed = adoc.parsed
         attributes = adoc.attributes
         lines = parsed.reader.source_lines

--- a/lib/pre.d/create_toc.rb
+++ b/lib/pre.d/create_toc.rb
@@ -7,6 +7,7 @@ require_relative '../utils/adoc.rb'
 require_relative '../log/log.rb'
 require 'json'
 require 'nokogiri'
+require 'fileutils'
 
 CM = Toolchain::ConfigManager.instance
 
@@ -40,6 +41,8 @@ module Toolchain
         json_filepath = @default_json_filepath,
         html_filepath = @default_html_filepath
       )
+        FileUtils.mkdir_p(File.dirname(@default_json_filepath))
+        FileUtils.mkdir_p(File.dirname(@default_html_filepath))
         # TODO: document this bit since it's quite confusing
         stage_log(:pre, '[Create TOC] Starting')
         if adoc.nil?

--- a/lib/stages/test.rb
+++ b/lib/stages/test.rb
@@ -85,7 +85,9 @@ end
 def run_tests(filename)
   if ADOC_MAP[filename].nil?
 
-    adoc = Toolchain::Adoc.load_doc(filename)
+    adoc = Toolchain::Adoc.load_doc(filename,
+      'root' => ::Toolchain.content_path
+    )
     original = adoc.original
     parsed = adoc.parsed
     attributes = adoc.attributes

--- a/lib/stages/test.rb
+++ b/lib/stages/test.rb
@@ -86,7 +86,7 @@ def run_tests(filename)
   if ADOC_MAP[filename].nil?
 
     adoc = Toolchain::Adoc.load_doc(filename,
-      'root' => ::Toolchain.content_path
+      'root' => ::Toolchain.document_root
     )
     original = adoc.original
     parsed = adoc.parsed

--- a/lib/utils/adoc.rb
+++ b/lib/utils/adoc.rb
@@ -17,6 +17,11 @@ module Toolchain
     #
     def self.load_doc(filename, attribs = {'root' => Toolchain.build_path})
       root = attribs['root']
+      if filename.start_with?('/')
+        root = File.dirname(filename)
+        attribs['root'] = root
+        filename = File.basename(filename)
+      end
       original = ::Asciidoctor.load_file(
         File.join(root, filename),
         catalog_assets: true,

--- a/lib/utils/adoc.rb
+++ b/lib/utils/adoc.rb
@@ -15,9 +15,10 @@ module Toolchain
     #
     # Returns a pair of converted adoc +adoc+, original adoc +original+
     #
-    def self.load_doc(filename, attribs = {'root' => Toolchain.document_root})
+    def self.load_doc(filename, attribs = {'root' => Toolchain.build_path})
+      root = attribs['root']
       original = ::Asciidoctor.load_file(
-        filename,
+        File.join(root, filename),
         catalog_assets: true,
         sourcemap: true,
         safe: :unsafe,
@@ -25,7 +26,7 @@ module Toolchain
         attributes: attribs
       )
       parsed = ::Asciidoctor.load_file(
-        filename,
+        File.join(root, filename),
         catalog_assets: true,
         sourcemap: true,
         safe: :unsafe,

--- a/lib/utils/setup.rb
+++ b/lib/utils/setup.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require_relative '../config_manager.rb'
+require_relative '../utils/paths.rb'
+require_relative '../log/log.rb'
+
+module Toolchain
+  # Module related to the setup of the build directory
+  module Setup
+    ##
+    # Setup build directory.
+    #
+    # Params:
+    # * +build_dir+ Build directory
+    #               (default: ConfigManager[:build_dir] || +DEFAULT_BUILD_DIR+)
+    # * +content+   Content directory (default: _content_)
+    #
+    # Raises error if directory does not exist.
+    #
+    # Returns nothing.
+    #
+    def self.setup(build_dir = ::Toolchain.build_path, content: 'content')
+      FileUtils.mkdir_p(build_dir) unless Dir.exists?(build_dir)
+      stage_log(:build, "setting up build dir @ #{build_dir}")
+      content_path = File.join(::Toolchain.content_path, content)
+      unless Dir.exist?(content_path)
+        error("Directory '#{content_path}' does not exist")
+        raise "Directory '#{content_path}' does not exist"
+      end
+
+      status = system("cp -r #{content_path}/* #{build_dir}")
+      raise "Could not cp #{content_path}/* to #{build_dir}" unless status
+    end
+  end
+end

--- a/test/test_pre_processes.rb
+++ b/test/test_pre_processes.rb
@@ -112,10 +112,8 @@ Sensing a pattern here?
 
     '
     adoc = init(adoc_content, "#{self.class.name}_#{__method__}")
-    puts "\n#{adoc.filename}"
     ::Toolchain::ConfigManager.instance.load
     json_filepath, html_filepath, toc_hash = ::Toolchain::Pre::CreateTOC.new.run(adoc)
-    puts "\n#{json_filepath}\n#{html_filepath}\n#{toc_hash}"
 
     # Test JSON file
     toc_object = JSON.parse(File.read(json_filepath))

--- a/test/test_pre_processes.rb
+++ b/test/test_pre_processes.rb
@@ -112,8 +112,10 @@ Sensing a pattern here?
 
     '
     adoc = init(adoc_content, "#{self.class.name}_#{__method__}")
+    puts "\n#{adoc.filename}"
     ::Toolchain::ConfigManager.instance.load
     json_filepath, html_filepath, toc_hash = ::Toolchain::Pre::CreateTOC.new.run(adoc)
+    puts "\n#{json_filepath}\n#{html_filepath}\n#{toc_hash}"
 
     # Test JSON file
     toc_object = JSON.parse(File.read(json_filepath))

--- a/test/util.rb
+++ b/test/util.rb
@@ -16,7 +16,8 @@ def write_tempfile(name, content, prefix: 'test_toolchain_', suffix: nil)
 end
 
 def with_tempfile(content, suffix = '')
-  file = write_tempfile('tmpfile', content, prefix: 'unittest_', suffix: suffix) # write tempfile with content
+  # write tempfile with content
+  file = write_tempfile('tmpfile', content, prefix: 'unittest_', suffix: suffix)
   yield(file) # call block with file as argument
 end
 


### PR DESCRIPTION
So far, only the build stage copied the contents from the document root to the build dir.
Since the Pre stage manipulates assets (and overwrites them), it should setup the build dir first and work inside the build dir exclusively.
This also removes the need for `git checkout` after every run and mitigates errors in relation to accidental commits containing changed files from the Pre stage.
