### PR TITLE
Post/coderay

### DIFF
--- a/lib/post.d/coderay_style.rb
+++ b/lib/post.d/coderay_style.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../process_manager.rb'
+require_relative '../utils/paths.rb'
+require_relative '../log/log.rb'
+
+module Toolchain
+  ##
+  # Adds modules for postprocessing files.
+  module Post
+    ##
+    # Copies the CodeRay style defined in `content/css/asciidoctor-coderay.css`
+    # to the build dir.
+    #
+    # NOTE This is a fix to mitigate an issue with asciidoctor and coderay,
+    # where the coderay style file is always written to disk,
+    # even if one already exsits (i.e. overwriting the style).
+    #
+    class CodeRayStyleCopy < BaseProcess
+      def run
+        coderay_css = 'asciidoctor-coderay.css'
+        stage_log(:post, "Copying CodeRay stylesheet to HTML directory: #{coderay_css}")
+        ::FileUtils.cp(
+          ::File.join(::Toolchain.document_root, 'css', coderay_css),
+          ::File.join(::Toolchain.html_path, 'css', coderay_css)
+        )
+      end
+    end
+  end
+end
+
+Toolchain::PostProcessManager.instance.register(Toolchain::Post::CodeRayStyleCopy.new)

--- a/lib/post.d/coderay_style.rb
+++ b/lib/post.d/coderay_style.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../base_process.rb'
 require_relative '../process_manager.rb'
 require_relative '../utils/paths.rb'
 require_relative '../log/log.rb'

--- a/lib/post.d/coderay_style.rb
+++ b/lib/post.d/coderay_style.rb
@@ -15,7 +15,7 @@ module Toolchain
     #
     # NOTE This is a fix to mitigate an issue with asciidoctor and coderay,
     # where the coderay style file is always written to disk,
-    # even if one already exsits (i.e. overwriting the style).
+    # even if one already exists (i.e. overwriting the style).
     #
     class CodeRayStyleCopy < BaseProcess
       def run


### PR DESCRIPTION
Asciidoctor CodeRay has an issue where the CodeRay stylesheet is always overwritten (this is intended behavior, just not suitable for us).
In order to fix this, and the overwriting of our defined stylesheet, we add a Post Processing action that copies the modified stylesheet to the HTML directory.