### PR TITLE
Add failure condition for Pre and Post stages

### DIFF
--- a/bin/post.rb
+++ b/bin/post.rb
@@ -18,11 +18,12 @@ def main(argv = ARGV)
     Toolchain::PostProcessManager.instance.get.each do |proc|
       log('PROC', proc.class.name)
     end
-    exit 0
+    exit 0 if args.list
   end
 
   stage_log(:post, 'Starting post-processing stage')
-  Toolchain::PostProcessManager.instance.run
+  ret = Toolchain::PostProcessManager.instance.run
+  exit ret
 end
 
 main

--- a/bin/pre.rb
+++ b/bin/pre.rb
@@ -18,11 +18,12 @@ def main(argv = ARGV)
     Toolchain::PreProcessManager.instance.get.each do |proc|
       log('PROC', proc.class.name)
     end
-    exit 0
+    exit 0 if args.list
   end
 
   stage_log(:pre, 'Starting pre-processing stage')
-  Toolchain::PreProcessManager.instance.run
+  ret = Toolchain::PreProcessManager.instance.run
+  exit ret
 end
 
 main

--- a/lib/post.d/html_check.rb
+++ b/lib/post.d/html_check.rb
@@ -47,7 +47,9 @@ module Toolchain
         )
         unless os.nil? || OS.bits != 64
           stage_log(:post, "Running htmltest #{@version} as #{os}")
-          system("#{bin} #{directory}")
+          unless system("#{bin} #{directory}") # returns false if failed
+            ::Toolchain::PostProcessManager.instance.return_code
+          end
         end
       end
     end

--- a/lib/process_manager.rb
+++ b/lib/process_manager.rb
@@ -36,6 +36,7 @@ module Toolchain
     #
     def run
       @processes.each(&:run)
+      return @code
     end
 
     ##
@@ -44,10 +45,18 @@ module Toolchain
       @processes.clear
     end
 
+    ##
+    # Set the return code `@code` to non-zero value `error_code`.
+    # This means the stage failed.
+    def return_code(error_code = 10)
+      @code = error_code
+    end
+
     private
 
     def initialize
       @processes = []
+      @code = 0
     end
   end
 


### PR DESCRIPTION
Add a failure mechanism that allows processes to _fail_ the entire Pre or Post stage.
An example can be seen in `html_check.rb`, where this is active when the call to `htmltest` shows errors.
