### PR TITLE
Add support for user config

### DIFF
--- a/bin/post.rb
+++ b/bin/post.rb
@@ -14,7 +14,7 @@ def main(argv = ARGV)
   end
 
   if args.list || args.debug
-    log('LOADED POST-PROCESSING', 'loaded processes:')
+    log('POST-PROCESSING', 'loaded processes:')
     Toolchain::PostProcessManager.instance.get.each do |proc|
       log('PROC', proc.class.name)
     end

--- a/bin/pre.rb
+++ b/bin/pre.rb
@@ -14,7 +14,7 @@ def main(argv = ARGV)
   end
 
   if args.list || args.debug
-    log('LOADED PRE-PROCESSING', 'loaded processes:')
+    log('PRE-PROCESSING', 'loaded processes:')
     Toolchain::PreProcessManager.instance.get.each do |proc|
       log('PROC', proc.class.name)
     end

--- a/config/log.json
+++ b/config/log.json
@@ -1,3 +1,0 @@
-{
-    "LOG_FILE": "/tmp/logs/messages.log.json"
-}

--- a/lib/config_manager.rb
+++ b/lib/config_manager.rb
@@ -50,8 +50,12 @@ module Toolchain
     #
     # Returns the configuration as hash (YAML parsed)
     def load(
-      file = File.join(Toolchain.toolchain_path, 'config', 'default.yaml')
+      file = File.join(Toolchain.content_path, 'config.yaml')
     )
+      unless File.exist?(file)
+        file = File.join(Toolchain.toolchain_path, 'config', 'default.yaml')
+      end
+
       @config = YAML.load_file(file)
       @loaded = true
     end

--- a/lib/stages/test.rb
+++ b/lib/stages/test.rb
@@ -35,9 +35,9 @@ end
 # print help
 # print all loaded extensions
 def print_loaded_extensions
-  puts '*** Loaded extensions:'
+  log('TESTING', 'loaded extensions:')
   Toolchain::ExtensionManager.instance.get.each do |ext|
-    puts ext.class.name
+    log('EXT', ext.class.name)
   end
 end
 

--- a/test/test_extensions.rb
+++ b/test/test_extensions.rb
@@ -266,6 +266,8 @@ class TestPatternBlacklist < Test::Unit::TestCase
 WPP
 document-center
 
+In this paragraph there is a bad_word. Oh no!
+
     '
     blacklist_patterns = '
 # do not match this comment
@@ -279,7 +281,7 @@ document
     blacklist_filepath = write_tempfile('blacklist_patterns.txt', blacklist_patterns)
     adoc = init(adoc, "#{self.class.name}_#{__method__}", 'test_toolchain_pattern_blacklist.adoc')
     errors = Toolchain::PatternBlacklist.new.run(adoc, blacklist_filepath)
-    assert_equal(3, errors.length)
+    assert_equal(4, errors.length)
   end
 
   def test_no_blacklist


### PR DESCRIPTION
Default to user config in the content repository when loading the config in `ConfigManager` and only use the toolchain config as fallback.

Resolves #96 