### PR TITLE
Allow content repository to define extensions and processes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,12 @@ require_relative 'lib/utils/setup.rb'
 
 task default: %w[toolchain:test toolchain:lint]
 
-FLAGS = '-E utf-8'
+def toolchain_path
+  ENV.key?('TOOLCHAIN_PATH') ? ENV['TOOLCHAIN_PATH'] : File.dirname(__FILE__)
+end
 
-# HELPER
+FLAGS = "-E utf-8 -I#{toolchain_path}/lib"
+
 def call script
   if ENV.key?('FAST')
     ENV['SKIP_RAKE_TEST'] = 'true'
@@ -17,10 +20,6 @@ def call script
   end
   debug = '--debug' if ENV.key?('DEBUG')
   ruby "#{FLAGS} #{toolchain_path}/#{script} #{debug}"
-end
-
-def toolchain_path
-  ENV.key?('TOOLCHAIN_PATH') ? ENV['TOOLCHAIN_PATH'] : File.dirname(__FILE__)
 end
 
 # TASKS
@@ -140,5 +139,6 @@ namespace :env do
     puts "DEBUG = #{ENV['DEBUG']}"
     puts "TOOLCHAIN_PATH = #{ENV['TOOLCHAIN_PATH']}"
     puts "UNITTEST = #{ENV['UNITTEST']}"
+    puts "LOAD_PATH = #{$LOAD_PATH}"
   end
 end

--- a/bin/post.rb
+++ b/bin/post.rb
@@ -4,8 +4,17 @@
 require_relative '../lib/cli.rb'
 require_relative '../lib/process_manager.rb'
 require_relative '../lib/log/log.rb'
-Dir[File.join(__dir__, '../', 'lib', 'post.d', '*.rb')].each { |file| require file }
+require_relative '../lib/utils/paths.rb'
 
+# require processes
+Dir[
+  File.join(__dir__, '../', 'lib', 'post.d', '*.rb')
+].each { |file| require file }
+Dir[
+  File.join(::Toolchain.custom_dir, 'post.d', '*.rb')
+].each { |file| require file }
+
+# MAIN
 def main(argv = ARGV)
   args, opt_parser = Toolchain::Process::CLI.parse_args(argv)
   if args.help

--- a/bin/pre.rb
+++ b/bin/pre.rb
@@ -4,8 +4,17 @@
 require_relative '../lib/cli.rb'
 require_relative '../lib/process_manager.rb'
 require_relative '../lib/log/log.rb'
-Dir[File.join(__dir__, '../', 'lib', 'pre.d', '*.rb')].each { |file| require file }
 
+# require processes
+Dir[
+  File.join(__dir__, '../', 'lib', 'pre.d', '*.rb')
+].each { |file| require file }
+Dir[
+  File.join(::Toolchain.custom_dir, 'pre.d', '*.rb')
+].each { |file| require file }
+
+
+# MAIN
 def main(argv = ARGV)
   args, opt_parser = Toolchain::Process::CLI.parse_args(argv)
   if args.help

--- a/lib/stages/test.rb
+++ b/lib/stages/test.rb
@@ -5,7 +5,15 @@ require_relative '../config_manager.rb'
 require_relative '../extension_manager.rb'
 require_relative '../log/log.rb'
 require_relative '../utils/adoc.rb'
-Dir[File.join(__dir__, '../', 'extensions.d', '*.rb')].each { |file| require file }
+require_relative '../utils/paths.rb'
+
+# require extensions
+Dir[
+  File.join(__dir__, '../', 'extensions.d', '*.rb')
+].each { |file| require file }
+Dir[
+  File.join(::Toolchain.custom_dir, 'extensions.d', '*.rb')
+].each { |file| require file }
 
 ##
 # hash to cache all filename: converted_adoc pairs
@@ -103,8 +111,8 @@ def run_tests(filename)
 
   errors = []
   Toolchain::ExtensionManager.instance.get.each do |ext|
-    # log('EXTENSION', ext.class.name, :cyan)
-    errors += ext.run(adoc)
+    result = ext.run(adoc)
+    errors += result if result.is_a?(Array)
   end
   return errors
 end

--- a/lib/utils/paths.rb
+++ b/lib/utils/paths.rb
@@ -61,6 +61,7 @@ module Toolchain
   # in the content repository.
   #
   def self.custom_dir
-    return File.join(content_path, ConfigManager.instance.get('custom.dir'))
+    return File.join(content_path,
+      ConfigManager.instance.get('custom.dir') || '')
   end
 end

--- a/lib/utils/paths.rb
+++ b/lib/utils/paths.rb
@@ -54,4 +54,13 @@ module Toolchain
   def self.html_path(path = nil)
     return (path.nil? ? ConfigManager.instance.get('build.html.dir') : path)
   end
+
+  ##
+  # custom_dir
+  # Returns the custom/ directory, which holds custom extensions and processes
+  # in the content repository.
+  #
+  def self.custom_dir
+    return File.join(content_path, ConfigManager.instance.get('custom.dir'))
+  end
 end


### PR DESCRIPTION
The config now has a field `custom.dir` which is used to load custom extensions and processes, in the folders:
* extensions.d
* pre.d
* post.d

When writing extensions and processes, `require 'base_process'` can be used to require `toolchain/lib/base_process.rb`.

Closes #89 