### PR TITLE
Use Thread Pool in Test stage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ gem "html-proofer", "~> 3.15"
 gem "os", "~> 1.0"
 
 gem "simplecov-lcov", "~> 0.8.0"
+
+gem "thread", "~> 0.2.2"

--- a/lib/extensions.d/pattern_blacklist.rb
+++ b/lib/extensions.d/pattern_blacklist.rb
@@ -21,7 +21,7 @@ module Toolchain
         ::Toolchain.content_path,
         ::Toolchain::ConfigManager.instance.get('checkers.pattern.blacklist'))
     )
-      log('PATTERN', "Blacklist file #{blacklist_file}")
+      log('PATTERN', "Blacklist file #{blacklist_file}") if ENV.key?('DEBUG')
       original = adoc.original
       parsed = adoc.parsed
       attributes = adoc.attributes
@@ -31,7 +31,7 @@ module Toolchain
           'PATTERN',
           "Blacklist file '#{blacklist_file}' not found. Skipping this test.",
           :magenta
-        )
+        ) if ENV.key?('DEBUG')
         return errors
       end
       blacklist_patterns = File.foreach(blacklist_file).map(&:chomp)


### PR DESCRIPTION
Since testing a single file is an independent process, we can easily improve performance by using threads, and even more so by using thread pools.

<img width="601" alt="image" src="https://user-images.githubusercontent.com/51907712/78331890-3c3eba00-7587-11ea-953a-5324083ae1e6.png">
