### PR TITLE
Add environment variables to paths.rb

### DIFF
--- a/lib/utils/paths.rb
+++ b/lib/utils/paths.rb
@@ -2,19 +2,21 @@
 
 require_relative '../config_manager.rb'
 
+# Toolchain module
 module Toolchain
   ##
   # content_path
   # Returns path to content directory root.
   #
   def self.content_path
-    content_dir_path = Dir.pwd
-    content_dir_path = File.join(Dir.pwd, '..') if File.basename(Dir.pwd) == 'toolchain'
-    if ENV.key?('TOOLCHAIN_TEST') || ENV.key?('GITHUB_ACTIONS')
-      content_dir_path = ENV['GITHUB_WORKSPACE']
+    content_dir = Dir.pwd
+    dir = File.basename(Dir.pwd)
+    content_dir = dir if dir == 'toolchain'
+
+    %w[GITHUB_WORKSPACE CONTENT_PATH].each do |envvar|
+      content_dir = ENV[envvar] if ENV.key?(envvar)
     end
-    content_dir_path = ENV['CONTENT_PATH'] if ENV.key?('CONTENT_PATH')
-    return content_dir_path
+    return content_dir
   end
 
   ##
@@ -22,6 +24,7 @@ module Toolchain
   # Returns the root of content structure, i.e. where +index.adoc+ is located.
   #
   def self.document_root
+    return ENV['DOCUMENT_ROOT'] if ENV.key?('DOCUMENT_ROOT')
     return File.join(content_path, 'content')
   end
 
@@ -30,10 +33,10 @@ module Toolchain
   # Returns path to toolchain root.
   #
   def self.toolchain_path
-    toolchain_dir_path = File.join(Dir.pwd, 'toolchain')
-    toolchain_dir_path = Dir.pwd unless File.exist?(toolchain_dir_path)
-    toolchain_dir_path = ENV['TOOLCHAIN_PATH'] if ENV.key?('TOOLCHAIN_PATH')
-    return toolchain_dir_path
+    toolchain_dir = File.join(Dir.pwd, 'toolchain')
+    toolchain_dir = Dir.pwd unless Dir.exist?(toolchain_dir)
+    toolchain_dir = ENV['TOOLCHAIN_PATH'] if ENV.key?('TOOLCHAIN_PATH')
+    return toolchain_dir
   end
 
   ##
@@ -41,6 +44,7 @@ module Toolchain
   # Returns path to toolchain build directory.
   #
   def self.build_path
+    return ENV['BUILD_PATH'] if ENV.key?('BUILD_PATH')
     return ConfigManager.instance.get('build.dir')
   end
 
@@ -48,7 +52,7 @@ module Toolchain
   # html_path
   # Returns path to generated html files.
   #
-  def self.html_path(path = nil)
+  def self.html_path
     return ENV['HTML_DIR'] if ENV.key?('HTML_DIR')
     return ConfigManager.instance.get('build.html.dir')
   end
@@ -59,6 +63,7 @@ module Toolchain
   # in the content repository.
   #
   def self.custom_dir
+    return ENV['CUSTOM_DIR'] if ENV.key?('CUSTOM_DIR')
     return File.join(content_path,
       ConfigManager.instance.get('custom.dir') || '')
   end

--- a/test/test_utils_git.rb
+++ b/test/test_utils_git.rb
@@ -6,21 +6,50 @@ require_relative './util.rb'
 
 class TestGit < Test::Unit::TestCase
   def test_parse_ref
-    a = 'a'
-    b = 'b'
-    c = 'a/b/c'
+    a = 'master'
+    b = 'fallback'
+    c = 'head/refs/master'
     assert_equal(a, Toolchain::Git.parse_ref(a, b))
     assert_equal(b, Toolchain::Git.parse_ref(nil, b))
-    assert_equal('c', Toolchain::Git.parse_ref(c, nil))
+    assert_equal('master', Toolchain::Git.parse_ref(c, nil))
     assert_nil(Toolchain::Git.parse_ref(nil, nil))
   end
 
   def test_git_info_full
-    git_info = Toolchain::Git.generate_info
+    git_info = nil
+    Dir.mktmpdir do |tmp|
+      Dir.chdir(tmp) do
+        repo = Git.init
+        File.open('test.txt', 'w+') { |f| f.puts("Test") }
+        repo.add('test.txt')
+        repo.commit('message')
+        ENV['CONTENT_PATH'] = tmp
+        git_info = Toolchain::Git.generate_info
+        ENV.delete('CONTENT_PATH')
+      end
+    end
+
     not_available = '<N/A>'
-    assert_not_equal(git_info.author, not_available)
-    assert_not_equal(git_info.commit, not_available)
-    assert_not_equal(git_info.branch, not_available)
-    assert_not_equal(git_info.time, not_available)
+    assert_not_equal(not_available, git_info.author)
+    assert_not_equal(not_available, git_info.commit)
+    assert_not_equal(not_available, git_info.branch)
+    assert_not_equal(not_available, git_info.time)
+  end
+
+  def test_git_info_na
+    git_info = nil
+    Dir.mktmpdir do |tmp|
+      Dir.chdir(tmp) do
+        ENV['CONTENT_PATH'] = tmp
+        git_info = Toolchain::Git.generate_info
+        ENV.delete('CONTENT_PATH')
+      end
+    end
+
+    not_available = '<N/A>'
+    assert_equal(not_available, git_info.author)
+    assert_equal(not_available, git_info.commit)
+    assert_equal(not_available, git_info.branch)
+    assert_equal(not_available, git_info.time)
   end
 end


### PR DESCRIPTION
- Improve `utils/git.rb` unit tests (broke with 57c9143eaaac143fcd48367a4ef735feb9e194ad)
- Add environment variables to overwrite `paths.rb` methods
